### PR TITLE
Add hover event UUID normalization plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Build output
+/target/
+
+# Local Maven archive
+/apache-maven-3.9.9-bin.tar.gz

--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
 # ItemsAdderFix
-Fix for ItemsAdder
+
+ItemsAdderFix is a lightweight hotfix plugin for Paper/Spigot 1.20.1 servers that use [ItemsAdder](https://www.spigotmc.org/resources/75974/) together with ProtocolLib. Some vanilla packets still ship entity hover events that use Mojang's legacy UUID representation (an integer array or `{most,least}` object). When ItemsAdder/LoneLibs/Adventure try to deserialize these payloads they expect a string UUID and throw a `JsonSyntaxException`.
+
+This plugin intercepts every outgoing Play packet through ProtocolLib with the lowest priority and normalizes the `hoverEvent` payloads so that entity UUIDs are always strings. This keeps ItemsAdder running without touching your existing configuration.
+
+## Requirements
+- Java 17 runtime
+- Paper or Spigot 1.20.1
+- [ProtocolLib 5.3.0+](https://github.com/dmulloy2/ProtocolLib) (already required by ItemsAdder)
+
+## Building
+```bash
+mvn package
+```
+The shaded jar will be produced in `target/itemsadderfix-1.0.0-shaded.jar` with Gson relocated to `com.ssilensio.itemsadderfix.libs.gson` to avoid dependency clashes.
+
+## Installation
+1. Place the generated jar into your server's `plugins/` folder.
+2. Ensure ProtocolLib is installed and updated to 5.3.0 or newer.
+3. Start or reload the server. The console will confirm that hover event normalization is active.
+
+## How it works
+- Registers a ProtocolLib listener with `ListenerPriority.LOWEST`, guaranteeing the fix runs before ItemsAdder's own listeners.
+- Scans chat components in outgoing packets.
+- Rewrites `hoverEvent:show_entity` payloads that carry legacy UUID formats (int arrays or `{most,least}` objects) into standard UUID strings.
+- Leaves already valid payloads untouched.
+
+No game mechanics are changed and no configuration options are added—this plugin simply prevents the `JsonSyntaxException` spam and crashes triggered by malformed hover event data.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,87 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.ssilensio</groupId>
+    <artifactId>itemsadderfix</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <name>ItemsAdderFix</name>
+    <description>Hotfix plugin that normalizes hoverEvent entity ids for ItemsAdder/LoneLibs compatibility.</description>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>papermc</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
+        <repository>
+            <id>dmulloy2</id>
+            <url>https://repo.dmulloy2.net/repository/public/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>1.20.1-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.comphenix.protocol</groupId>
+            <artifactId>ProtocolLib</artifactId>
+            <version>5.3.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10.1</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
+                    <release>${maven.compiler.target}</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.3</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.google.gson</pattern>
+                                    <shadedPattern>com.ssilensio.itemsadderfix.libs.gson</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/ssilensio/itemsadderfix/ItemsAdderFix.java
+++ b/src/main/java/com/ssilensio/itemsadderfix/ItemsAdderFix.java
@@ -1,0 +1,283 @@
+package com.ssilensio.itemsadderfix;
+
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.ProtocolLibrary;
+import com.comphenix.protocol.ProtocolManager;
+import com.comphenix.protocol.events.ListenerPriority;
+import com.comphenix.protocol.events.PacketAdapter;
+import com.comphenix.protocol.events.PacketContainer;
+import com.comphenix.protocol.events.PacketEvent;
+import com.comphenix.protocol.wrappers.WrappedChatComponent;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.logging.Level;
+
+public final class ItemsAdderFix extends JavaPlugin {
+    private final Gson gson = new Gson();
+    private ProtocolManager protocolManager;
+    private PacketAdapter listener;
+
+    @Override
+    public void onEnable() {
+        if (!isProtocolLibPresent()) {
+            getLogger().severe("ProtocolLib is required to run ItemsAdderFix. Disabling plugin.");
+            getServer().getPluginManager().disablePlugin(this);
+            return;
+        }
+
+        protocolManager = ProtocolLibrary.getProtocolManager();
+        PacketType[] monitoredTypes = collectServerPlayPackets();
+        listener = new PacketAdapter(this, ListenerPriority.LOWEST, monitoredTypes) {
+            @Override
+            public void onPacketSending(PacketEvent event) {
+                try {
+                    normalizePacket(event.getPacket());
+                } catch (Exception ex) {
+                    getLogger().log(Level.SEVERE, "Failed to normalize packet " + event.getPacketType(), ex);
+                }
+            }
+        };
+
+        protocolManager.addPacketListener(listener);
+        getLogger().info("ItemsAdderFix enabled. Hover event UUID normalization active.");
+    }
+
+    @Override
+    public void onDisable() {
+        if (protocolManager != null && listener != null) {
+            protocolManager.removePacketListener(listener);
+        }
+    }
+
+    private boolean isProtocolLibPresent() {
+        Plugin plugin = getServer().getPluginManager().getPlugin("ProtocolLib");
+        return plugin != null && plugin.isEnabled();
+    }
+
+    private void normalizePacket(PacketContainer packet) {
+        if (packet == null) {
+            return;
+        }
+
+        var components = packet.getChatComponents();
+        if (components == null) {
+            return;
+        }
+
+        for (int i = 0; i < components.size(); i++) {
+            WrappedChatComponent component;
+            try {
+                component = components.readSafely(i);
+            } catch (Exception ignored) {
+                continue;
+            }
+
+            if (component == null) {
+                continue;
+            }
+
+            String json = component.getJson();
+            if (json == null || json.isEmpty()) {
+                continue;
+            }
+
+            String normalized = normalizeJson(json);
+            if (!Objects.equals(json, normalized)) {
+                components.write(i, WrappedChatComponent.fromJson(normalized));
+            }
+        }
+    }
+
+    private PacketType[] collectServerPlayPackets() {
+        List<PacketType> types = new ArrayList<>();
+        for (PacketType type : PacketType.values()) {
+            if (!type.isSupported()) {
+                continue;
+            }
+            if (type.getProtocol() != PacketType.Protocol.PLAY) {
+                continue;
+            }
+            if (type.getSender() != PacketType.Sender.SERVER) {
+                continue;
+            }
+            types.add(type);
+        }
+        return types.toArray(new PacketType[0]);
+    }
+
+    private String normalizeJson(String json) {
+        JsonElement element;
+        try {
+            element = gson.fromJson(json, JsonElement.class);
+        } catch (JsonParseException ex) {
+            return json;
+        }
+
+        if (element == null || element.isJsonNull()) {
+            return json;
+        }
+
+        boolean changed = normalizeElement(element);
+        return changed ? gson.toJson(element) : json;
+    }
+
+    private boolean normalizeElement(JsonElement element) {
+        if (element == null || element.isJsonNull()) {
+            return false;
+        }
+
+        boolean changed = false;
+
+        if (element.isJsonObject()) {
+            JsonObject object = element.getAsJsonObject();
+            for (Map.Entry<String, JsonElement> entry : object.entrySet()) {
+                if ("hoverEvent".equals(entry.getKey()) && entry.getValue().isJsonObject()) {
+                    changed |= normalizeHoverEvent(entry.getValue().getAsJsonObject());
+                } else {
+                    changed |= normalizeElement(entry.getValue());
+                }
+            }
+        } else if (element.isJsonArray()) {
+            JsonArray array = element.getAsJsonArray();
+            for (JsonElement child : array) {
+                changed |= normalizeElement(child);
+            }
+        }
+
+        return changed;
+    }
+
+    private boolean normalizeHoverEvent(JsonObject hoverEvent) {
+        boolean changed = false;
+
+        String action = getString(hoverEvent, "action");
+        if (action != null && "show_entity".equalsIgnoreCase(action)) {
+            changed |= normalizeShowEntityPayload(hoverEvent, "value");
+            changed |= normalizeShowEntityPayload(hoverEvent, "contents");
+        }
+
+        for (Map.Entry<String, JsonElement> entry : hoverEvent.entrySet()) {
+            changed |= normalizeElement(entry.getValue());
+        }
+
+        return changed;
+    }
+
+    private boolean normalizeShowEntityPayload(JsonObject hoverEvent, String key) {
+        if (!hoverEvent.has(key)) {
+            return false;
+        }
+
+        JsonElement payload = hoverEvent.get(key);
+        boolean changed = false;
+
+        if (payload.isJsonObject()) {
+            changed |= normalizeEntityTooltip(payload.getAsJsonObject());
+        } else if (payload.isJsonArray()) {
+            JsonArray array = payload.getAsJsonArray();
+            for (JsonElement element : array) {
+                if (element.isJsonObject()) {
+                    changed |= normalizeEntityTooltip(element.getAsJsonObject());
+                }
+                changed |= normalizeElement(element);
+            }
+        } else {
+            changed |= normalizeElement(payload);
+        }
+
+        return changed;
+    }
+
+    private boolean normalizeEntityTooltip(JsonObject tooltip) {
+        boolean changed = false;
+
+        if (tooltip.has("id")) {
+            JsonElement idElement = tooltip.get("id");
+            String uuidString = extractUuid(idElement);
+            if (uuidString != null) {
+                tooltip.addProperty("id", uuidString);
+                changed = true;
+            }
+        }
+
+        for (Map.Entry<String, JsonElement> entry : tooltip.entrySet()) {
+            if ("id".equals(entry.getKey())) {
+                continue;
+            }
+            changed |= normalizeElement(entry.getValue());
+        }
+
+        return changed;
+    }
+
+    private String extractUuid(JsonElement element) {
+        if (element == null || element.isJsonNull()) {
+            return null;
+        }
+
+        if (element.isJsonPrimitive()) {
+            JsonPrimitive primitive = element.getAsJsonPrimitive();
+            if (primitive.isString()) {
+                return null;
+            }
+            return null;
+        }
+
+        if (element.isJsonArray()) {
+            JsonArray array = element.getAsJsonArray();
+            if (array.size() != 4) {
+                return null;
+            }
+
+            long[] parts = new long[4];
+            for (int i = 0; i < 4; i++) {
+                JsonElement part = array.get(i);
+                if (!part.isJsonPrimitive() || !part.getAsJsonPrimitive().isNumber()) {
+                    return null;
+                }
+                parts[i] = part.getAsLong() & 0xFFFFFFFFL;
+            }
+
+            long most = (parts[0] << 32) | parts[1];
+            long least = (parts[2] << 32) | parts[3];
+            return new UUID(most, least).toString();
+        }
+
+        if (element.isJsonObject()) {
+            JsonObject object = element.getAsJsonObject();
+            if (object.has("most") && object.has("least")) {
+                try {
+                    long most = object.get("most").getAsLong();
+                    long least = object.get("least").getAsLong();
+                    return new UUID(most, least).toString();
+                } catch (RuntimeException ignored) {
+                    return null;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private String getString(JsonObject object, String key) {
+        if (object.has(key)) {
+            JsonElement element = object.get(key);
+            if (element.isJsonPrimitive() && element.getAsJsonPrimitive().isString()) {
+                return element.getAsString();
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,0 +1,7 @@
+name: ItemsAdderFix
+version: ${project.version}
+main: com.ssilensio.itemsadderfix.ItemsAdderFix
+depend: [ProtocolLib]
+api-version: '1.20'
+description: 'Normalizes hoverEvent entity ids to avoid JsonSyntaxException in ItemsAdder.'
+author: ssilensio


### PR DESCRIPTION
## Summary
- set up a Maven-based ItemsAdderFix plugin module with shaded Gson and ProtocolLib provided dependency
- intercept outgoing play packets with a LOWEST priority listener and rewrite show_entity hover event IDs into string UUIDs
- document build, requirements, and installation steps for deploying the hotfix

## Testing
- mvn package

------
https://chatgpt.com/codex/tasks/task_e_68dec7b914dc8320b777824662773b48