### PR TITLE
Add configurable logging for XML hover event normalization

### DIFF
--- a/src/java/com/ssilensio/itemsadderfix/ItemsAdderFix.java
+++ b/src/java/com/ssilensio/itemsadderfix/ItemsAdderFix.java
@@ -28,6 +28,7 @@ public final class ItemsAdderFix extends JavaPlugin {
     private final Gson gson = new Gson();
     private ProtocolManager protocolManager;
     private PacketAdapter listener;
+    private boolean logFixes;
 
     @Override
     public void onEnable() {
@@ -36,6 +37,10 @@ public final class ItemsAdderFix extends JavaPlugin {
             getServer().getPluginManager().disablePlugin(this);
             return;
         }
+
+        saveDefaultConfig();
+        reloadConfig();
+        logFixes = getConfig().getBoolean("log-fixes", true);
 
         protocolManager = ProtocolLibrary.getProtocolManager();
         PacketType[] monitoredTypes = collectServerPlayPackets();
@@ -208,8 +213,10 @@ public final class ItemsAdderFix extends JavaPlugin {
             JsonElement idElement = tooltip.get("id");
             String uuidString = extractUuid(idElement);
             if (uuidString != null) {
+                String original = gson.toJson(idElement);
                 tooltip.addProperty("id", uuidString);
                 changed = true;
+                logFix(original, uuidString);
             }
         }
 
@@ -301,5 +308,12 @@ public final class ItemsAdderFix extends JavaPlugin {
             System.out.println(line);
         }
         System.out.println();
+    }
+
+    private void logFix(String before, String after) {
+        if (!logFixes) {
+            return;
+        }
+        getLogger().info(() -> "Normalized hoverEvent entity id from XML payload " + before + " to " + after + ".");
     }
 }

--- a/src/resources/config.yml
+++ b/src/resources/config.yml
@@ -1,0 +1,3 @@
+# Configuration for ItemsAdderFix
+# Set to true to log every time the hover event UUID normalization alters XML payloads.
+log-fixes: true


### PR DESCRIPTION
## Summary
- add a default configuration file to toggle XML fix logging
- load the configuration during startup and capture the logging preference
- emit a log entry whenever the hover event UUID normalization alters the XML payload

## Testing
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68dee3e7a8188320a0fdb7f5417b4f0a