### PR TITLE
Tighten handled error logging and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@ The shaded jar will be produced in `target/itemsadderfix-1.0.0-shaded.jar` with 
 2. Ensure ProtocolLib is installed and updated to 5.3.0 or newer.
 3. Start or reload the server. The console will confirm that hover event normalization is active.
 
+## Configuration
+ItemsAdderFix ships with a minimal configuration file located at `plugins/ItemsAdderFix/config.yml`:
+
+```yaml
+# Configuration for ItemsAdderFix
+# Set to true to log every time the hover event UUID normalization alters XML payloads.
+log-fixes: true
+```
+
+When `log-fixes` is enabled, normalized payload pairs are appended to `plugins/ItemsAdderFix/handled-errors.xml` so you can audit what the plugin adjusted. Malformed or empty payload data is ignored, ensuring the XML only tracks genuine fixes. Set the value to `false` if you do not want the XML log to be updated.
+
 ## How it works
 - Registers a ProtocolLib listener with `ListenerPriority.LOWEST`, guaranteeing the fix runs before ItemsAdder's own listeners.
 - Scans chat components in outgoing packets.

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,12 @@
             <artifactId>gson</artifactId>
             <version>2.10.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -87,6 +93,14 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/java/com/ssilensio/itemsadderfix/logging/HandledErrorLogger.java
+++ b/src/java/com/ssilensio/itemsadderfix/logging/HandledErrorLogger.java
@@ -1,0 +1,207 @@
+package com.ssilensio.itemsadderfix.logging;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Persists normalized hover event conversions into handled-errors.xml so users
+ * can inspect which payloads were fixed. The logger is deliberately strict
+ * about the data it accepts and will quietly skip malformed requests to avoid
+ * polluting the log with unrelated entries.
+ */
+public final class HandledErrorLogger {
+    private final Logger logger;
+    private final File dataFolder;
+    private final Object lock = new Object();
+    private File handledErrorsFile;
+    private boolean initialized;
+
+    public HandledErrorLogger(Logger logger, File dataFolder) {
+        this.logger = Objects.requireNonNull(logger, "logger");
+        this.dataFolder = dataFolder;
+    }
+
+    public boolean initialize() {
+        if (initialized) {
+            return handledErrorsFile != null;
+        }
+
+        if (dataFolder == null) {
+            return false;
+        }
+
+        synchronized (lock) {
+            if (initialized) {
+                return handledErrorsFile != null;
+            }
+
+            if (!dataFolder.exists() && !dataFolder.mkdirs()) {
+                logger.warning("Unable to create plugin data folder; handled error logging disabled.");
+                return false;
+            }
+
+            handledErrorsFile = new File(dataFolder, "handled-errors.xml");
+
+            try {
+                DocumentBuilder builder = newDocumentBuilder();
+                Document document;
+                if (!handledErrorsFile.exists() || handledErrorsFile.length() == 0) {
+                    document = builder.newDocument();
+                    document.appendChild(document.createElement("handledErrors"));
+                    writeDocument(document);
+                } else {
+                    try (FileInputStream inputStream = new FileInputStream(handledErrorsFile)) {
+                        document = builder.parse(inputStream);
+                    }
+                    if (document.getDocumentElement() == null) {
+                        document.appendChild(document.createElement("handledErrors"));
+                        writeDocument(document);
+                    }
+                }
+                initialized = true;
+                return true;
+            } catch (ParserConfigurationException | IOException | TransformerException ex) {
+                logger.log(Level.WARNING, "Unable to initialize handled-errors.xml", ex);
+                handledErrorsFile = null;
+                return false;
+            } catch (Exception ex) {
+                logger.log(Level.WARNING, "Failed to verify handled-errors.xml; recreating file.", ex);
+                try {
+                    DocumentBuilder builder = newDocumentBuilder();
+                    Document document = builder.newDocument();
+                    document.appendChild(document.createElement("handledErrors"));
+                    writeDocument(document);
+                    initialized = true;
+                    return true;
+                } catch (ParserConfigurationException | TransformerException | IOException recreateEx) {
+                    logger.log(Level.WARNING, "Unable to recreate handled-errors.xml", recreateEx);
+                    handledErrorsFile = null;
+                    return false;
+                }
+            }
+        }
+    }
+
+    public boolean logNormalization(String original, String normalized) {
+        if (!initialized || handledErrorsFile == null) {
+            return false;
+        }
+        if (original == null || normalized == null) {
+            return false;
+        }
+        if (original.isBlank() || normalized.isBlank()) {
+            return false;
+        }
+
+        synchronized (lock) {
+            try {
+                DocumentBuilder builder = newDocumentBuilder();
+                Document document;
+                if (handledErrorsFile.exists() && handledErrorsFile.length() > 0) {
+                    try (FileInputStream inputStream = new FileInputStream(handledErrorsFile)) {
+                        document = builder.parse(inputStream);
+                    }
+                } else {
+                    document = builder.newDocument();
+                    document.appendChild(document.createElement("handledErrors"));
+                }
+
+                Element root = document.getDocumentElement();
+                if (root == null) {
+                    root = document.createElement("handledErrors");
+                    document.appendChild(root);
+                }
+
+                Element entry = document.createElement("handledError");
+                entry.setAttribute("timestamp", Instant.now().toString());
+
+                Element originalElement = document.createElement("original");
+                originalElement.appendChild(document.createCDATASection(original));
+                Element normalizedElement = document.createElement("normalized");
+                normalizedElement.appendChild(document.createCDATASection(normalized));
+
+                entry.appendChild(originalElement);
+                entry.appendChild(normalizedElement);
+                root.appendChild(entry);
+
+                writeDocument(document);
+                return true;
+            } catch (Exception ex) {
+                logger.log(Level.WARNING, "Unable to write handled error entry to handled-errors.xml", ex);
+                return false;
+            }
+        }
+    }
+
+    private DocumentBuilder newDocumentBuilder() throws ParserConfigurationException {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
+        factory.setIgnoringComments(true);
+        factory.setExpandEntityReferences(false);
+        try {
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        } catch (ParserConfigurationException ignored) {
+            // Fall back to defaults when a feature is unavailable.
+        }
+        try {
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        } catch (IllegalArgumentException ignored) {
+            // Attributes may not be supported by all parser implementations.
+        }
+        return factory.newDocumentBuilder();
+    }
+
+    private Transformer newTransformer() throws TransformerException {
+        TransformerFactory factory = TransformerFactory.newInstance();
+        try {
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+        } catch (IllegalArgumentException | TransformerException ignored) {
+            // Some implementations may not support these attributes.
+        }
+        Transformer transformer = factory.newTransformer();
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+        transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+        return transformer;
+    }
+
+    private void writeDocument(Document document) throws TransformerException, IOException {
+        if (handledErrorsFile == null) {
+            return;
+        }
+
+        Transformer transformer = newTransformer();
+        DOMSource source = new DOMSource(document);
+        try (FileOutputStream outputStream = new FileOutputStream(handledErrorsFile, false)) {
+            StreamResult result = new StreamResult(outputStream);
+            transformer.transform(source, result);
+        }
+    }
+}

--- a/src/test/java/com/ssilensio/itemsadderfix/logging/HandledErrorLoggerTest.java
+++ b/src/test/java/com/ssilensio/itemsadderfix/logging/HandledErrorLoggerTest.java
@@ -1,0 +1,86 @@
+package com.ssilensio.itemsadderfix.logging;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.nio.file.Path;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HandledErrorLoggerTest {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void createsLogFileAndAppendsHandledErrorEntries() throws Exception {
+        File dataFolder = tempDir.toFile();
+        Logger logger = Logger.getLogger("HandledErrorLoggerTest");
+        HandledErrorLogger handledErrorLogger = new HandledErrorLogger(logger, dataFolder);
+
+        assertTrue(handledErrorLogger.initialize());
+
+        File logFile = dataFolder.toPath().resolve("handled-errors.xml").toFile();
+        assertTrue(logFile.exists(), "handled-errors.xml should be created during initialization");
+
+        assertTrue(handledErrorLogger.logNormalization("[0,1,2,3]", "c0ffee-cafe-babe-face-feeddeadbeef"));
+
+        Document document = parseDocument(logFile);
+        NodeList handledErrors = document.getDocumentElement().getElementsByTagName("handledError");
+        assertEquals(1, handledErrors.getLength(), "Exactly one handled error entry should be recorded");
+
+        Element entry = (Element) handledErrors.item(0);
+        assertTrue(entry.hasAttribute("timestamp"));
+        assertEquals("[0,1,2,3]", entry.getElementsByTagName("original").item(0).getTextContent());
+        assertEquals("c0ffee-cafe-babe-face-feeddeadbeef", entry.getElementsByTagName("normalized").item(0).getTextContent());
+    }
+
+    @Test
+    void skipsWritingWhenOriginalOrNormalizedMissing() throws Exception {
+        File dataFolder = tempDir.resolve("skip").toFile();
+        Logger logger = Logger.getLogger("HandledErrorLoggerSkipTest");
+        HandledErrorLogger handledErrorLogger = new HandledErrorLogger(logger, dataFolder);
+
+        assertTrue(handledErrorLogger.initialize());
+        File logFile = dataFolder.toPath().resolve("handled-errors.xml").toFile();
+
+        assertFalse(handledErrorLogger.logNormalization(null, "value"));
+        assertFalse(handledErrorLogger.logNormalization("", "value"));
+        assertFalse(handledErrorLogger.logNormalization("value", null));
+        assertFalse(handledErrorLogger.logNormalization("value", "   "));
+
+        Document document = parseDocument(logFile);
+        NodeList handledErrors = document.getDocumentElement().getElementsByTagName("handledError");
+        assertEquals(0, handledErrors.getLength(), "No handled error entries should be recorded when data is invalid");
+    }
+
+    private Document parseDocument(File file) throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
+        disableExternalEntities(factory);
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        try (FileInputStream stream = new FileInputStream(file)) {
+            return builder.parse(stream);
+        }
+    }
+
+    private void disableExternalEntities(DocumentBuilderFactory factory) throws ParserConfigurationException {
+        try {
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        } catch (ParserConfigurationException ignored) {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extract handled error logging into a dedicated helper so initialization failures disable logging and malformed payloads are skipped
- document the logger safeguards in the README and add JUnit-based coverage that verifies only valid conversions reach handled-errors.xml
- add JUnit Jupiter and the Surefire plugin so the new tests run under Maven

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_e_68dee686dd208320b0542b3f2c37993c