### PR TITLE
Handle byte-array hover event UUID payloads

### DIFF
--- a/src/test/java/com/ssilensio/itemsadderfix/ItemsAdderFixTest.java
+++ b/src/test/java/com/ssilensio/itemsadderfix/ItemsAdderFixTest.java
@@ -1,0 +1,29 @@
+package com.ssilensio.itemsadderfix;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonPrimitive;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ItemsAdderFixTest {
+    @Test
+    void convertsSignedByteArrayUuidPayload() throws Exception {
+        UUID expected = UUID.fromString("12345678-1234-5678-90ab-cdef12345678");
+        ByteBuffer buffer = ByteBuffer.allocate(16);
+        buffer.putLong(expected.getMostSignificantBits());
+        buffer.putLong(expected.getLeastSignificantBits());
+        byte[] uuidBytes = buffer.array();
+
+        JsonArray payload = new JsonArray();
+        for (byte value : uuidBytes) {
+            payload.add(new JsonPrimitive((int) value));
+        }
+
+        String normalized = ItemsAdderFix.extractUuidFromIntArray(payload);
+        assertEquals(expected.toString(), normalized);
+    }
+}


### PR DESCRIPTION
## Summary
- allow hover event normalization to convert both int-array formats and byte-array UUID payloads into strings
- add a unit test covering conversion of signed byte array payloads

## Testing
- `mvn test`


------
https://chatgpt.com/codex/tasks/task_e_68dfcaa1803c83209c0f20448c4aff9a